### PR TITLE
docs: update README.md adding iOS command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Follow these steps to run the game in your local environment!
     npx expo start
     ```
 
+4. **Run the project iOS:**
+    ```bash
+    npx expo start --ios
+    ```
+
 Use the **Expo Go** app on your mobile device or an emulator to test the game. 📲
 
 ---


### PR DESCRIPTION
## 🔗 Related Issue
Closes #1 

---

## 📝 Description
This PR addresses an environment configuration issue that prevented the iOS simulator from launching. No source code changes were made to the project itself.

**Problem:**
When running `npx expo start --ios`, the command failed with the error `xcrun simctl help exited with non-zero code: 72`. This happened because the system was pointing to the standalone "Command Line Tools" instead of the full Xcode application.

**Solution:**
Updated the active developer directory to use the full Xcode application by running:
`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`

The iOS simulator now launches correctly as expected.
