### PR TITLE
Fixes the navigation flow and input animation logic 

### DIFF
--- a/app/game/victory.tsx
+++ b/app/game/victory.tsx
@@ -26,59 +26,61 @@ export default function VictoryScreen() {
 
     const handleHome = () => {
         resetGame();
-        router.replace('/');
+        router.replace('/home');
     };
 
     return (
-        <ScreenWrapper className="justify-between py-8 px-6">
-            <View className="items-center flex-1 justify-center w-full">
-                <View className="mb-6 items-center justify-center">
-                    <Trophy size={64} color="#E5533D" strokeWidth={1.5} />
+        <ScreenWrapper className="py-8">
+            <View className="flex-1 justify-between">
+                <View className="items-center flex-1 justify-center w-full">
+                    <View className="mb-6 items-center justify-center">
+                        <Trophy size={64} color="#E5533D" strokeWidth={1.5} />
+                    </View>
+
+                    <AppText className="text-primary-action font-black text-4xl text-center leading-tight mb-2 uppercase">
+                        {winner === 'impostor' ? t.victory.impostorsWin : t.victory.civiliansWin}
+                    </AppText>
+
+                    <AppText className="text-text-secondary text-sm text-center mb-8 px-10">
+                        {winner === 'impostor'
+                            ? t.victory.reasonImpostor
+                            : t.victory.reasonCivilian}
+                    </AppText>
+
+                    <View className={`${isDark ? 'bg-[#182235]' : 'bg-white shadow-lg border border-gray-100'} w-full p-6 rounded-[32px] items-center`}>
+                        <AppText className={`font-black text-[10px] uppercase tracking-[3px] mb-2 ${isDark ? 'text-[#B6C2E2]' : 'text-gray-500'}`}>
+                            {t.victory.secretWordWas}
+                        </AppText>
+                        <AppText className={`text-3xl font-black text-center ${isDark ? 'text-white' : 'text-[#101828]'}`}>
+                            {secretWord}
+                        </AppText>
+                    </View>
                 </View>
 
-                <AppText className="text-primary-action font-black text-4xl text-center leading-tight mb-2 uppercase">
-                    {winner === 'impostor' ? t.victory.impostorsWin : t.victory.civiliansWin}
-                </AppText>
+                <View className="items-center gap-5 mt-8 pb-4">
+                    <Button
+                        title={t.victory.playAgain}
+                        onPress={handlePlayAgain}
+                        className="w-4/5 h-12"
+                        icon={<RefreshCw size={18} color="white" />}
+                        iconPosition="left"
+                        textClassName="text-base"
+                    />
 
-                <AppText className="text-text-secondary text-sm text-center mb-8 px-10">
-                    {winner === 'impostor'
-                        ? t.victory.reasonImpostor
-                        : t.victory.reasonCivilian}
-                </AppText>
-
-                <View className={`${isDark ? 'bg-[#182235]' : 'bg-white shadow-lg border border-gray-100'} w-full p-6 rounded-[32px] items-center`}>
-                    <AppText className={`font-black text-[10px] uppercase tracking-[3px] mb-2 ${isDark ? 'text-[#B6C2E2]' : 'text-gray-500'}`}>
-                        {t.victory.secretWordWas}
-                    </AppText>
-                    <AppText className={`text-3xl font-black text-center ${isDark ? 'text-white' : 'text-[#101828]'}`}>
-                        {secretWord}
-                    </AppText>
-                </View>
-            </View>
-
-            <View className="w-full items-center gap-5 mt-8 pb-4">
-                <Button
-                    title={t.victory.playAgain}
-                    onPress={handlePlayAgain}
-                    className="w-4/5 h-12"
-                    icon={<RefreshCw size={18} color="white" />}
-                    iconPosition="left"
-                    textClassName="text-base"
-                />
-
-                <TouchableOpacity
-                    onPress={handleHome}
-                    activeOpacity={0.7}
-                    className="flex-row items-center justify-center py-2"
-                >
-                    <Home size={18} color={isDark ? "#B6C2E2" : "#98A2B3"} />
-                    <AppText
-                        className={`ml-2 font-bold text-base ${isDark ? "text-[#B6C2E2]" : "text-gray-500"}`}
-                        style={{ includeFontPadding: false }}
+                    <TouchableOpacity
+                        onPress={handleHome}
+                        activeOpacity={0.7}
+                        className="flex-row items-center justify-center py-2"
                     >
-                        {t.victory.backHome}
-                    </AppText>
-                </TouchableOpacity>
+                        <Home size={18} color={isDark ? "#B6C2E2" : "#98A2B3"} />
+                        <AppText
+                            className={`ml-2 font-bold text-base ${isDark ? "text-[#B6C2E2]" : "text-gray-500"}`}
+                            style={{ includeFontPadding: false }}
+                        >
+                            {t.victory.backHome}
+                        </AppText>
+                    </TouchableOpacity>
+                </View>
             </View>
         </ScreenWrapper>
     );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,19 @@
-import { useRouter } from 'expo-router';
+import { Redirect, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useRef } from 'react';
 import { Animated, Image, Text, View } from 'react-native';
+import { useSettingsStore } from '../store/settingsStore';
 
 import splashLogo from '../assets/images/splash_logo.png';
 
 export default function SplashScreen() {
     const router = useRouter();
+    const { hasSeenSplash, setHasSeenSplash } = useSettingsStore();
     const fadeAnim = useRef(new Animated.Value(0)).current;
 
     useEffect(() => {
+        if (hasSeenSplash) return;
+
         fadeAnim.setValue(0);
 
         Animated.sequence([
@@ -26,9 +30,16 @@ export default function SplashScreen() {
                 useNativeDriver: true,
             }),
         ]).start(({ finished }) => {
-            if (finished) router.replace('/home');
+            if (finished) {
+                setHasSeenSplash(true);
+                router.replace('/home');
+            }
         });
-    }, []);
+    }, [hasSeenSplash]);
+
+    if (hasSeenSplash) {
+        return <Redirect href="/home" />;
+    }
 
     return (
         <View style={{ flex: 1, backgroundColor: 'white', justifyContent: 'center', alignItems: 'center' }}>

--- a/store/settingsStore.ts
+++ b/store/settingsStore.ts
@@ -6,13 +6,17 @@ export type AppTheme = 'dark' | 'light';
 interface SettingsState {
     language: Language;
     appTheme: AppTheme;
+    hasSeenSplash: boolean;
     setLanguage: (lang: Language) => void;
     setAppTheme: (theme: AppTheme) => void;
+    setHasSeenSplash: (seen: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
     language: 'es',
     appTheme: 'dark',
+    hasSeenSplash: false,
     setLanguage: (language) => set({ language }),
     setAppTheme: (appTheme) => set({ appTheme }),
+    setHasSeenSplash: (hasSeenSplash) => set({ hasSeenSplash }),
 }));


### PR DESCRIPTION
 ## 🔗 Related Issue
Closes #18 

---

## 📝 Description
This PR fixes the navigation flow and input animation logic to improve user experience and resolve redundant behaviors identified in the results screen.

### Key Changes:
- **Session Control**: Added a `hasSeenSplash` property to [settingsStore.ts](cci:7://file:///Users/josue/Personal_Projects/el-impostor-game/store/settingsStore.ts:0:0-0:0) to track if the introduction animation has already been shown in the current session.
- **Efficient Navigation**: Modified [app/index.tsx](cci:7://file:///Users/josue/Personal_Projects/el-impostor-game/app/index.tsx:0:0-0:0) to include the `Redirect` component from `expo-router`. This ensures that if the animation has already run once (cold start), subsequent navigations to the start are instantaneous and flicker-free.
- **Route Correction**: Updated the logic in the results screen ([victory.tsx](cci:7://file:///Users/josue/Personal_Projects/el-impostor-game/app/game/victory.tsx:0:0-0:0)) to redirect directly to `/home`, preventing the animation entry point from being triggered unnecessarily.
- **Animation Logic**: The splash sequence now only executes on the first launch of the application, marking its state as completed upon finishing the fade sequence.

---

## 📸 Screenshots (if applicable)
*Transitions between screens have been optimized; navigation buttons now lead directly to the main menu without re-executing the animated logo.*