### PR TITLE
bugFix: integrate next round functionality in elimination screen

### DIFF
--- a/app/game/elimination.tsx
+++ b/app/game/elimination.tsx
@@ -11,7 +11,7 @@ import { useGameStore } from '../../store/gameStore';
 import { useSettingsStore } from '../../store/settingsStore';
 
 export default function EliminationScreen() {
-    const { players, eliminatedPlayerId, checkVictoryAfterElimination: checkVictory, resolveImpostorGuess, undoElimination } = useGameStore();
+    const { players, eliminatedPlayerId, checkVictoryAfterElimination: checkVictory, resolveImpostorGuess, undoElimination, nextRound } = useGameStore();
     const { appTheme } = useSettingsStore();
     const isDark = appTheme === 'dark';
     const router = useRouter();
@@ -33,6 +33,7 @@ export default function EliminationScreen() {
         if (victory) {
             router.replace('/game/victory');
         } else {
+            nextRound();
             router.replace('/game/round-start');
         }
     };


### PR DESCRIPTION
### 🔗 Related Issue
Closes #22

---

### 📝 Description
This PR fixes a bug where eliminated players were incorrectly shown as the starting player in subsequent rounds. 

**Key Changes:**
- Updated [elimination.tsx](file:///d:/Coding%20projects/el-impostor-game/app/game/elimination.tsx) to call `nextRound()` before navigating to the next round's start screen.
- This ensures that a new, alive player is randomly selected as the starter for the new round.

---

### 📸 Screenshots (if applicable)
<!-- Add screenshots or GIFs if the changes affect the UI -->
N/A
